### PR TITLE
Remove console output when disposing WriteApi

### DIFF
--- a/Client/WriteApi.cs
+++ b/Client/WriteApi.cs
@@ -194,12 +194,12 @@ namespace InfluxDB.Client
                     exception =>
                     {
                         _disposed = true;
-                        Console.WriteLine($"The unhandled exception occurs: {exception}");
+                        Trace.WriteLine($"The unhandled exception occurs: {exception}");
                     },
                     () =>
                     {
                         _disposed = true;
-                        Console.WriteLine("The WriteApi was disposed.");
+                        Trace.WriteLine("The WriteApi was disposed.");
                     });
         }
 


### PR DESCRIPTION
Changed from `Console.WriteLine` to `Trace.WriteLine` to avoid console output when disposing `WriteApi`.

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] Tests pass
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)